### PR TITLE
feat: migrate file upload to Cloudinary and update tests

### DIFF
--- a/express-backend/__test__/documentoLocalService.test.js
+++ b/express-backend/__test__/documentoLocalService.test.js
@@ -1,81 +1,91 @@
 const request = require('supertest');
 const express = require('express');
-const documentoRouter = require('../services/documentoLocalService'); 
+const fileUpload = require('express-fileupload');
+const documentoRouter = require('../services/documentoLocalService');
 const DocumentoLocal = require('../models/DocumentoLocal');
+const cloudinary = require('../services/cloudinary');
 const path = require('path');
 
-// Mocks y configuración
+// Mocks
 jest.mock('../models/DocumentoLocal');
+jest.mock('../services/cloudinary');
 
 const app = express();
 app.use(express.json());
-app.use('/', documentoRouter); 
+app.use(fileUpload({ useTempFiles: true, tempFileDir: '/tmp/' }));
+app.use('/', documentoRouter);
 
 describe('Documento Local Service API', () => {
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-    test('GET / - debe retornar todos los documentos', async () => {
-  const mockDocs = [{
-    id: 1,
-    nombre: 'Doc Prueba',
-    archivo: '/uploads/doc1.pdf',
-    creacion: '2025-01-01',
-    vencimiento: '2026-01-01',
-    usuario: { id: 1, nombre: 'Juan', apellidos: 'Pérez', email: 'juan@correo.com', rol_id: 1 },
-    local: { id: 1, nombre: 'Sucursal A', direccion: 'Av 1', nit_emisor: '12345678' }
-  }];
+  test('GET / - debe retornar todos los documentos', async () => {
+    const mockDocs = [{
+      id: 1,
+      nombre: 'Doc Prueba',
+      archivo: 'https://url.com/doc1.pdf',
+      creacion: '2025-01-01',
+      vencimiento: '2026-01-01',
+      usuario: { id: 1, nombre: 'Juan', apellidos: 'Pérez', email: 'juan@correo.com', rol_id: 1 },
+      local: { id: 1, nombre: 'Sucursal A', direccion: 'Av 1', nit_emisor: '12345678' }
+    }];
 
-  DocumentoLocal.query.mockReturnValue({
-    modify: jest.fn().mockReturnThis(),
-    withGraphFetched: jest.fn().mockReturnThis(),
-    modifyGraph: jest.fn().mockReturnThis(),
-    then: (cb) => Promise.resolve(cb(mockDocs)) 
+    DocumentoLocal.query.mockReturnValue({
+      whereNull: jest.fn().mockReturnThis(),
+      modify: jest.fn().mockReturnThis(),
+      withGraphFetched: jest.fn().mockReturnThis(),
+      modifyGraph: jest.fn().mockReturnThis(),
+      then: (cb) => Promise.resolve(cb(mockDocs))
+    });
+
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('nombre', 'Doc Prueba');
   });
 
-  const res = await request(app).get('/');
-  expect(res.statusCode).toBe(200);
-  expect(Array.isArray(res.body)).toBe(true);
-  expect(res.body[0]).toHaveProperty('nombre', 'Doc Prueba');
-});
+  test('GET /:id - debe retornar un documento por ID', async () => {
+    const mockDoc = {
+      id: 1,
+      nombre: 'Doc 1',
+      archivo: 'https://url.com/doc1.pdf',
+      creacion: '2025-01-01',
+      vencimiento: '2026-01-01',
+      usuario: { id: 1, nombre: 'Juan', apellidos: 'Pérez', email: 'juan@correo.com' },
+      local: { id: 1, nombre: 'Sucursal A', direccion: 'Av 1', nit_emisor: '12345678' }
+    };
 
-test('GET /:id - debe retornar un documento por ID', async () => {
-  const mockDoc = {
-    id: 1,
-    nombre: 'Doc 1',
-    archivo: '/uploads/doc1.pdf',
-    creacion: '2025-01-01',
-    vencimiento: '2026-01-01',
-    usuario: { id: 1, nombre: 'Juan', apellidos: 'Pérez', email: 'juan@correo.com' },
-    local: { id: 1, nombre: 'Sucursal A', direccion: 'Av 1', nit_emisor: '12345678' }
-  };
+    DocumentoLocal.query.mockReturnValue({
+      findById: jest.fn().mockReturnThis(),
+      whereNull: jest.fn().mockReturnThis(),
+      withGraphFetched: jest.fn().mockReturnThis(),
+      modifyGraph: jest.fn().mockReturnThis(),
+      then: (cb) => Promise.resolve(cb(mockDoc))
+    });
 
-  DocumentoLocal.query.mockReturnValue({
-    findById: jest.fn().mockReturnThis(),
-    withGraphFetched: jest.fn().mockReturnThis(),
-    modifyGraph: jest.fn().mockReturnThis(),
-    then: (cb) => Promise.resolve(cb(mockDoc))
+    const res = await request(app).get('/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('nombre', 'Doc 1');
   });
 
-  const res = await request(app).get('/1');
-  expect(res.statusCode).toBe(200);
-  expect(res.body).toHaveProperty('nombre', 'Doc 1');
-});
-
-
-  test('POST / - debe crear un nuevo documento', async () => {
+  test('POST / - debe crear un nuevo documento con archivo', async () => {
     const nuevoDoc = {
       nombre: 'Nuevo Documento',
       usuario_id: '1',
-      local_id: '1'
+      local_id: '1',
+      vencimiento: '2025-12-31'
     };
+
+    // Simular subida exitosa a Cloudinary
+    cloudinary.uploader.upload.mockResolvedValue({
+      secure_url: 'https://cloudinary.com/fake.pdf'
+    });
 
     const mockResult = {
       id: 10,
       ...nuevoDoc,
-      archivo: '/uploads/fake.pdf'
+      archivo: 'https://cloudinary.com/fake.pdf'
     };
 
     DocumentoLocal.query.mockReturnValue({
@@ -87,15 +97,16 @@ test('GET /:id - debe retornar un documento por ID', async () => {
       .field('nombre', nuevoDoc.nombre)
       .field('usuario_id', nuevoDoc.usuario_id)
       .field('local_id', nuevoDoc.local_id)
+      .field('vencimiento', nuevoDoc.vencimiento)
       .attach('archivo', path.resolve(__dirname, 'mocks/fake.pdf'));
 
     expect(res.statusCode).toBe(201);
     expect(res.body).toHaveProperty('nombre', 'Nuevo Documento');
-    expect(res.body).toHaveProperty('archivo');
+    expect(res.body.archivo).toMatch(/^https:\/\/cloudinary\.com/);
   });
 
   test('PUT /:id - debe actualizar un documento existente', async () => {
-    const updateData = { nombre: 'Doc Actualizado' };
+    const updateData = { nombre: 'Doc Actualizado', updatedat: new Date().toISOString() };
     const mockUpdated = { id: 1, ...updateData };
 
     DocumentoLocal.query.mockReturnValue({
@@ -110,24 +121,28 @@ test('GET /:id - debe retornar un documento por ID', async () => {
     expect(res.body).toHaveProperty('nombre', 'Doc Actualizado');
   });
 
-  test('DELETE /:id - debe eliminar un documento', async () => {
+  test('DELETE /:id - debe eliminar lógicamente un documento', async () => {
+    const eliminado = {
+      id: 1,
+      deletedat: new Date().toISOString()
+    };
+
     DocumentoLocal.query.mockReturnValue({
-      deleteById: jest.fn().mockResolvedValue(1)
+      patchAndFetchById: jest.fn().mockResolvedValue(eliminado)
     });
 
     const res = await request(app).delete('/1');
     expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('mensaje', 'Documento eliminado correctamente');
+    expect(res.body).toHaveProperty('mensaje', 'Documento eliminado lógicamente');
   });
 
   test('DELETE /:id - debe retornar 404 si no encuentra el documento', async () => {
     DocumentoLocal.query.mockReturnValue({
-      deleteById: jest.fn().mockResolvedValue(0)
+      patchAndFetchById: jest.fn().mockResolvedValue(null)
     });
 
     const res = await request(app).delete('/999');
     expect(res.statusCode).toBe(404);
     expect(res.body).toHaveProperty('error', 'Documento no encontrado');
   });
-
 });

--- a/express-backend/database/migrations/20250720_migracion17.js
+++ b/express-backend/database/migrations/20250720_migracion17.js
@@ -8,7 +8,7 @@ exports.up = function(knex) {
 };
 
 exports.down = async function(knex) {
-  // Revertir inserciones de tipos de movimientos
+  // Revertir inserciones de tipos de movimiento
   await knex('inventario').del();
   await knex('lotes').whereIn('id', [1, 2]).del();
   await knex('Tipos_Movimientos_Inventario')

--- a/express-backend/index.js
+++ b/express-backend/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');  
+const fileUpload = require('express-fileupload');
 require('dotenv').config();
 const Knex = require('knex');
 const { Model } = require('objection');
@@ -27,6 +28,13 @@ app.use(cors({
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
   credentials: true
 }));
+
+
+app.use(fileUpload({
+  useTempFiles: true,
+  tempFileDir: '/tmp/'
+}));
+
 app.use(express.json());
 app.use('/uploads', express.static('uploads'));
 

--- a/express-backend/services/cloudinary.js
+++ b/express-backend/services/cloudinary.js
@@ -1,0 +1,9 @@
+const cloudinary = require('cloudinary').v2;
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key:    process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+module.exports = cloudinary;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
             "version": "1.0.0",
             "dependencies": {
                 "bcryptjs": "^3.0.2",
+                "cloudinary": "^2.7.0",
                 "cors": "^2.8.5",
                 "dotenv": "^16.3.1",
                 "express": "~5.1.0",
                 "express-backend": "file:",
+                "express-fileupload": "^1.5.2",
                 "jsonwebtoken": "9.0.2",
                 "knex": "2.5.1",
-                "multer": "^2.0.1",
                 "nodemailer": "6.10.1",
                 "objection": "3.1.5",
                 "pg": "8.13.3"
@@ -1186,12 +1187,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/append-field": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
-            "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-            "license": "MIT"
-        },
         "node_modules/argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1392,9 +1387,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1468,6 +1463,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/busboy": {
@@ -1673,6 +1669,19 @@
                 "node": ">=12"
             }
         },
+        "node_modules/cloudinary": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.7.0.tgz",
+            "integrity": "sha512-qrqDn31+qkMCzKu1GfRpzPNAO86jchcNwEHCUiqvPHNSFqu7FTNF9FuAkBUyvM1CFFgFPu64NT0DyeREwLwK0w==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash": "^4.17.21",
+                "q": "^1.5.1"
+            },
+            "engines": {
+                "node": ">=9"
+            }
+        },
         "node_modules/co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1755,21 +1764,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/concat-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-            "engines": [
-                "node >= 6.0"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.0.2",
-                "typedarray": "^0.0.6"
-            }
         },
         "node_modules/content-disposition": {
             "version": "1.0.0",
@@ -2258,6 +2252,18 @@
             "resolved": "",
             "link": true
         },
+        "node_modules/express-fileupload": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.5.2.tgz",
+            "integrity": "sha512-wxUJn2vTHvj/kZCVmc5/bJO15C7aSMyHeuXYY3geKpeKibaAoQGcEv5+sM6nHS2T7VF+QHS4hTWPiY2mKofEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "busboy": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2349,15 +2355,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -3997,93 +4004,11 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
-        },
-        "node_modules/multer": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-            "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "append-field": "^1.0.0",
-                "busboy": "^1.6.0",
-                "concat-stream": "^2.0.0",
-                "mkdirp": "^0.5.6",
-                "object-assign": "^4.1.1",
-                "type-is": "^1.6.18",
-                "xtend": "^4.0.2"
-            },
-            "engines": {
-                "node": ">= 10.16.0"
-            }
-        },
-        "node_modules/multer/node_modules/media-typer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/multer/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/multer/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/multer/node_modules/type-is": {
-            "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-            "license": "MIT",
-            "dependencies": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.24"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4629,6 +4554,17 @@
             ],
             "license": "MIT"
         },
+        "node_modules/q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.0",
+                "teleport": ">=0.2.0"
+            }
+        },
         "node_modules/qs": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -4674,20 +4610,6 @@
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -5081,15 +5003,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
         "node_modules/string-length": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5334,12 +5247,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "license": "MIT"
-        },
         "node_modules/undefsafe": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -5393,12 +5300,6 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     },
     "dependencies": {
         "bcryptjs": "^3.0.2",
+        "cloudinary": "^2.7.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "~5.1.0",
         "express-backend": "file:",
+        "express-fileupload": "^1.5.2",
         "jsonwebtoken": "9.0.2",
         "knex": "2.5.1",
-        "multer": "^2.0.1",
         "nodemailer": "6.10.1",
         "objection": "3.1.5",
         "pg": "8.13.3"


### PR DESCRIPTION
### Cambios realizados

- Se eliminó `multer` como manejador de archivos.
- Se integró `express-fileupload` para recibir archivos y subirlos a Cloudinary.
- Se añadió soporte para guardar la URL pública del archivo subido en la base de datos.
- Se mockeó la subida a Cloudinary en los tests unitarios.
- Se actualizó la suite de pruebas de `documentoLocalService` usando `jest` y `supertest`.

### Motivación

Este cambio mejora la escalabilidad y portabilidad del backend, eliminando la dependencia de almacenamiento local en favor de un servicio en la nube (Cloudinary). También permite visualizar documentos desde cualquier parte vía URL pública.

### Notas

- Se requiere tener configuradas las variables de entorno de Cloudinary (`CLOUDINARY_CLOUD_NAME`, `API_KEY`, `API_SECRET`).
- Para probar desde el frontend, las solicitudes deben enviarse como `multipart/form-data`.

### Revisión sugerida

- Verificar comportamiento de endpoints `POST` y `PUT /documentos-locales`
- Validar que los tests se ejecutan correctamente (`npm test`)